### PR TITLE
Fix minor issues in quick start install section

### DIFF
--- a/docs/Quick_Start/Quick_Start.md
+++ b/docs/Quick_Start/Quick_Start.md
@@ -2,35 +2,39 @@
 sidebar_position: 1
 id: 'Install-Chaos-Genius'
 ---
+
 # Install Chaos Genius
 
 Note: These instructions have been tested on MacOS, Windows 10 and Ubuntu 20.04.
 
 If you are facing any issues with the installation, drop a line to the Chaos Genius team and community on our Slack channel. 
 
-Alternatively, visit our [Troubleshooting](#) section to find resolution for some of the most common issues raised by the community while trying to set up Chaos Genius. 
+Alternatively, visit our [Troubleshooting](/Troubleshooting/tips.md) section to find resolution for some of the most common issues raised by the community while trying to set up Chaos Genius. 
 
 
-## Setup Chaos Genius on MacOS, Ubuntu
+## Setup on Linux or MacOS
 
-Install Docker on your workstation (see [instructions](https://www.docker.com/products/docker-desktop)). 
+Install Docker on your workstation (see [instructions](https://www.docker.com/get-started)).
 
 *Note: There is a known issue with docker-compose 1.27.3. If you are using that version, please upgrade to 1.27.4.*
 
 Once Docker is installed successfully, get started on your local machine by running:
 
-```
+```bash
 git clone https://github.com/chaos-genius/chaos_genius
 
 cd chaos_genius
 
 docker-compose up
 ```
-Once you see the Chaos Genius success banner, the UI is ready to be accessed at[http://127.0.0.1:8080](http://127.0.0.1:8080)
 
-Some users using Macs with an M1 processor (Apple Silicon) are facing some problems in deploying Chaos Genius. The problem is related to the chip and Docker. If you are facing any other issues while installing, please visit our section on [Troubleshooting.](/Troubleshooting/tips.md)
+Once you see the Chaos Genius success banner, the UI is ready to be accessed at [http://localhost:8080](http://localhost:8080)
 
-## Setup Chaos Genius on Windows
+Macs with Apple Silicon (M1) processors are currently not supported due to issues related to Docker.
+
+If you face any other issues while installing, please visit the [Troubleshooting](/Troubleshooting/tips.md) section.
+
+## Setup on Windows
 
 You need to install Docker on Windows workstation, please follow the steps mentioned [here](https://docs.docker.com/desktop/windows/install/).
 
@@ -42,9 +46,9 @@ git clone https://github.com/chaos-genius/chaos_genius
 cd chaos_genius
 
 docker-compose up
-
 ```
-Before running these commands, please make sure your docker compose is up to date. Once you see the Chaos Genius success banner, the UI is ready to be accessed at [http://127.0.0.1:8080](http://127.0.0.1:8080).
+
+Before running these commands, please make sure your docker compose is up to date. Once you see the Chaos Genius success banner, the UI is ready to be accessed at [http://localhost:8080](http://localhost:8080).
 
 ## Next Steps
 

--- a/docs/Quick_Start/Quick_Start.md
+++ b/docs/Quick_Start/Quick_Start.md
@@ -30,7 +30,7 @@ docker-compose up
 
 Once you see the Chaos Genius success banner, the UI is ready to be accessed at [http://localhost:8080](http://localhost:8080)
 
-Macs with Apple Silicon (M1) processors are currently not supported due to issues related to Docker.
+Macs with Apple Silicon (M1) processors are currently not supported due to issues related to Docker. Follow [this issue](https://github.com/chaos-genius/chaos_genius/issues/292) for updates.
 
 If you face any other issues while installing, please visit the [Troubleshooting](/Troubleshooting/tips.md) section.
 


### PR DESCRIPTION
# Fixes

- Troubleshooting section was not linked correctly
- Docker instructions link was to product page instead of getting started
- Replaced 127.0.0.1 with localhost since that issue was fixed and localhost is more user friendly
- Reworded M1 issue (it was unnecessarily verbose)
    - and separated Troubleshooting link into a different paragraph
    - Also linked the GitHub Issue we had opened for this
- Removed "Chaos Genius" from sub-headings. It was redundant.
- Added bash syntax highlighting to commands